### PR TITLE
Added process manager (pmgr) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ pgbouncer_SOURCES = \
 	src/objects.c \
 	src/pam.c \
 	src/pktbuf.c \
+	src/pmgr.c \
 	src/pooler.c \
 	src/proto.c \
 	src/sbuf.c \
@@ -34,6 +35,7 @@ pgbouncer_SOURCES = \
 	include/objects.h \
 	include/pam.h \
 	include/pktbuf.h \
+	include/pmgr.h \
 	include/pooler.h \
 	include/proto.h \
 	include/sbuf.h \

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,24 @@ AC_CHECK_FUNCS(lstat)
 dnl Find libevent
 AC_USUAL_LIBEVENT
 
+dnl Check for process manager support
+pmgr_support=no
+AC_ARG_WITH(pmgr,
+  AC_HELP_STRING([--with-pmgr],[Enable process manager]),
+  [ PMGR=
+    if test "$withval" != no; then
+        have_pthreads=no
+        AC_CHECK_HEADERS(pthread.h, [have_pthreads=yes])
+        AC_SEARCH_LIBS(pthread_create, pthread, [], [have_pthreads=no])
+        if test x"${have_pthreads}" != xyes; then
+           AC_MSG_ERROR([pthread library should be available for pmgr support])
+        else
+           pmgr_support=yes
+           AC_DEFINE(HAVE_PMGR, 1, [pmgr support])
+        fi
+    fi
+  ], [])
+
 dnl Check for PAM authorization support
 pam_support=no
 AC_ARG_WITH(pam,
@@ -206,4 +224,5 @@ echo "  evdns = $use_evdns"
 echo "  udns = $use_udns"
 echo "  tls = $tls_support"
 echo "  PAM = $pam_support"
+echo "  pmgr = $pmgr_support"
 echo ""

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -13,6 +13,13 @@ and "#" are not recognized when they appear later in the line.
 Generic settings
 ================
 
+pmgr_workers
+------------
+
+If this option is set to an integer value greater than 1, the process manager will be enabled. Process manager will fork itself into 1 manager and ``pmgr_workers`` worker processes delegating each newly connected client to one of the workers. When this option is specified ``unix_socket_dir`` must be specified and ``pidfile`` must not be specified. Daemonization and process takeover are not supported.
+
+Default: not set.
+
 logfile
 -------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -98,6 +98,7 @@ extern int cf_sbuf_len;
 #include "loader.h"
 #include "client.h"
 #include "server.h"
+#include "pmgr.h"
 #include "pooler.h"
 #include "proto.h"
 #include "objects.h"
@@ -183,6 +184,14 @@ const char *pga_ntop(const PgAddr *a, char *dst, int dstlen);
 const char *pga_str(const PgAddr *a, char *dst, int dstlen);
 const char *pga_details(const PgAddr *a, char *dst, int dstlen);
 int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
+
+struct ListenSocket {
+	struct List node;
+	int fd;
+	bool active;
+	struct event ev;
+	PgAddr addr;
+};
 
 /*
  * Stats, kept per-pool.
@@ -389,6 +398,8 @@ struct PgSocket {
 
 /* main.c */
 extern int cf_daemon;
+extern bool cf_is_pmgr_worker;
+extern int cf_pmgr_workers;
 
 extern char *cf_config_file;
 extern char *cf_jobname;

--- a/include/pmgr.h
+++ b/include/pmgr.h
@@ -1,0 +1,24 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Process manager.
+ */
+
+void pmgr_run(void);
+void pmgr_worker_setup(void);

--- a/include/util.h
+++ b/include/util.h
@@ -45,6 +45,10 @@ void get_random_bytes(uint8_t *dest, int len);
 const char *bin2hex(const uint8_t *src, unsigned srclen, char *dst, unsigned dstlen);
 
 bool tune_socket(int sock, bool is_unix) _MUSTCHECK;
+void tune_accept(int sock, bool on);
+
+void create_sockets(struct StatList *sock_list);
+void cleanup_sockets(struct StatList *sock_list);
 
 bool strlist_contains(const char *liststr, const char *str);
 

--- a/src/pmgr.c
+++ b/src/pmgr.c
@@ -1,0 +1,590 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Process Manager.
+ */
+
+#include "bouncer.h"
+
+#ifdef HAVE_PMGR
+
+#include <sys/wait.h>
+
+#include <event2/thread.h>
+#include <usual/event.h>
+#include <usual/pthread.h>
+#include <usual/signal.h>
+
+
+/* Helpers */
+static struct Worker *next_worker(void);
+static void close_sockets(struct StatList *sock_list);
+
+/* Event Handlers */
+static void pmgr_on_accept(int sock, short flags, void *arg);
+static void pmgr_on_write(int sock, short flags, void *arg);
+static void worker_on_accept(int sock, short flags, void *arg);
+static void worker_on_read(int sock, short flags, void *arg);
+
+/* Signal Handlers */
+static void on_sigusr1(int sig, short flags, void *arg);
+static void on_sigusr2(int sig, short flags, void *arg);
+static void on_sighup(int sig, short flags, void *arg);
+static void on_sigterm(int sig, short flags, void *arg);
+static void on_sigint(int sig, short flags, void *arg);
+
+/* Setup & Cleanup */
+static void signals_setup(void);
+static void accept_start(void);
+static bool pmgr_setup(void);
+static void pmgr_cleanup(void);
+
+
+/*****************************************************************************
+ * Types
+ *****************************************************************************/
+
+typedef void (*event_cb_t)(int, short, void *);
+
+/*
+ * Used by manager, stores info about worker.
+ */
+struct Worker {
+	struct List node;
+	struct event ev_write;
+	pid_t pid;
+	int port;
+	int sock;
+};
+
+/*
+ * Used by worker, stores info about manager.
+ */
+struct PMgr {
+	struct event ev_read;
+	int sock;
+};
+
+
+/*****************************************************************************
+ * Globals
+ *****************************************************************************/
+
+static STATLIST(worker_list);
+static STATLIST(socket_list);
+
+static char *cf_pmgr_listen_addr;
+static int cf_pmgr_listen_port;
+
+static struct event ev_sigusr1;
+static struct event ev_sigusr2;
+static struct event ev_sighup;
+static struct event ev_sigterm;
+static struct event ev_sigint;
+
+static struct PMgr pmgr;
+
+
+/*****************************************************************************
+ * Helpers
+ *****************************************************************************/
+
+static struct Worker *next_worker(void)
+{
+	struct List *el;
+
+	el = statlist_pop(&worker_list);
+	statlist_append(&worker_list, el);
+	return container_of(el, struct Worker, node);
+}
+
+/*
+ * This function differs from cleanup_sockets() in that it doesn't unlink()
+ * the socket files, just closes the descriptors. This is useful for
+ * unreferencing the file descriptor after fork() in the parent.
+ */
+static void close_sockets(struct StatList *sock_list)
+{
+	struct ListenSocket *ls;
+	struct List *el;
+
+	while ((el = statlist_pop(sock_list)) != NULL) {
+		ls = container_of(el, struct ListenSocket, node);
+
+		if (ls->fd > 0) {
+			safe_close(ls->fd);
+		}
+		statlist_remove(sock_list, &ls->node);
+		free(ls);
+	}
+}
+
+
+/*****************************************************************************
+ * Event Handlers
+ *****************************************************************************/
+
+static void pmgr_on_accept(int sock, short flags, void *arg)
+{
+	struct Worker *worker;
+	int client_sock;
+	int *on_write_arg;
+
+	client_sock = safe_accept(sock, NULL, NULL);
+	if (client_sock < 0) {
+		if (errno != EAGAIN && errno != EWOULDBLOCK)
+			log_error("accept() failed: %s", strerror(errno));
+		return;
+	}
+
+	on_write_arg = malloc(sizeof(*on_write_arg));
+	if (!on_write_arg) {
+		log_error("malloc() failed: %s", strerror(errno));
+		goto cleanup;
+	}
+
+	*on_write_arg = client_sock;
+	worker = next_worker();
+
+	event_set(&worker->ev_write, worker->sock, EV_WRITE,
+		  pmgr_on_write, on_write_arg);
+
+	if (event_add(&worker->ev_write, NULL) < 0) {
+		log_warning("event_add() failed: %s", strerror(errno));
+		goto cleanup;
+	}
+
+	log_info("new connection on %d, sending to worker %d",
+		 client_sock, worker->pid);
+	return;
+
+cleanup:
+	if (client_sock >= 0)
+		safe_close(client_sock);
+	if (on_write_arg)
+		free(on_write_arg);
+}
+
+static void pmgr_on_write(int sock, short flags, void *arg)
+{
+	int *client_sock = arg;
+	struct Worker *worker;
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	struct iovec io;
+	char control[CMSG_SPACE(sizeof(int))];
+	char iobuf[1];
+
+	memset(&msg, 0, sizeof(msg));
+	io.iov_base = iobuf;
+	io.iov_len = sizeof(iobuf);
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+
+	memcpy(CMSG_DATA(cmsg), client_sock, sizeof(int));
+
+	if (safe_sendmsg(sock, &msg, 0) < 0) {
+		/*
+		 * We try to send the socket to another worker.
+		 */
+		worker = next_worker();
+
+		log_error("sendmsg(client_sock=%d) failed: %s, "
+			  "sending to worker %d",
+			  *client_sock, strerror(errno), worker->pid);
+
+		event_set(&worker->ev_write, worker->sock, EV_WRITE,
+			  pmgr_on_write, client_sock);
+
+		if (event_add(&worker->ev_write, NULL) < 0) {
+			log_error("event_add() failed: %s", strerror(errno));
+			goto cleanup;
+		}
+		return;
+	}
+
+	log_info("Client socket %d sent to worker", *client_sock);
+
+cleanup:
+	safe_close(*client_sock);
+	free(client_sock);
+}
+
+/*
+ * Manager only has one shot at connecting to worker. If it fails
+ * to do so, there's no point keeping the worker alive.
+ * Therefore we fatal() on any error.
+ */
+static void worker_on_accept(int sock, short flags, void *arg)
+{
+	pmgr.sock = safe_accept(sock, NULL, NULL);
+	if (pmgr.sock < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			return;
+		fatal_perror("accept() failed");
+	}
+
+	event_set(&pmgr.ev_read, pmgr.sock, EV_READ | EV_PERSIST,
+		  worker_on_read, NULL);
+
+	if (event_add(&pmgr.ev_read, NULL) < 0) {
+		safe_close(pmgr.sock);
+		fatal_perror("event_add() failed");
+	}
+
+	log_info("Established connection to manager");
+}
+
+static void worker_on_read(int sock, short flags, void *arg)
+{
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	struct iovec io;
+	PgSocket *client;
+	ssize_t len;
+	int *socks;
+	int client_sock = -1;
+	char control[CMSG_SPACE(sizeof(int))];
+	char iobuf[1];
+
+	memset(&msg, 0, sizeof(msg));
+	io.iov_base = iobuf;
+	io.iov_len = sizeof(iobuf);
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_controllen = sizeof(control);
+	msg.msg_control = control;
+
+	len = safe_recvmsg(sock, &msg, 0);
+	if (len < 0) {
+		log_error("worker_on_read(): recvmsg() failed");
+		return;
+	}
+
+	if (!len) {
+		/* Manager closed the connection, there's nothing
+		   else to do but to shutdown. */
+		cf_shutdown = 2;
+		return;
+	}
+
+	for (cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+		if (cmsg->cmsg_level == SOL_SOCKET &&
+		    cmsg->cmsg_type == SCM_RIGHTS) {
+			socks = (int *)CMSG_DATA(cmsg);
+			client_sock = *socks;
+		}
+	}
+
+	if (client_sock < 0) {
+		log_warning("worker_on_read(): invalid client socket");
+		return;
+	}
+
+	log_info("New client socket %d from manager", client_sock);
+
+	client = accept_client(client_sock, true);
+	if (!client) {
+		log_error("worker_on_read(): accept_client() failed");
+		safe_close(client_sock);
+		return;
+	}
+
+	slog_debug(client, "accepted client");
+}
+
+
+/*****************************************************************************
+ * Signal Handlers
+ *****************************************************************************/
+static void on_sigusr1(int sig, short flags, void *arg)
+{
+	log_info("Got SIGUSR1, forwarding to workers");
+	kill(0, sig);
+}
+
+static void on_sigusr2(int sig, short flags, void *arg)
+{
+	log_info("Got SIGUSR2 forwarding to workers");
+	kill(0, sig);
+}
+
+static void on_sighup(int sig, short flags, void *arg)
+{
+	log_info("Got SIGHUP, forwarding to workers");
+	kill(0, sig);
+}
+
+static void on_sigterm(int sig, short flags, void *arg)
+{
+	log_info("Got SIGTERM, forceful exit");
+	exit(1);
+}
+
+static void on_sigint(int sig, short flags, void *arg)
+{
+	log_info("Got SIGINT, graceful exit");
+	cf_shutdown = 2;
+}
+
+
+/*****************************************************************************
+ * Setup & Cleanup
+ *****************************************************************************/
+
+static void signals_setup(void)
+{
+	int ret;
+	sigset_t set;
+
+	/* Block SIGPIPE. */
+	sigemptyset(&set);
+	sigaddset(&set, SIGPIPE);
+	ret = sigprocmask(SIG_BLOCK, &set, NULL);
+	if (ret < 0)
+		fatal_perror("sigprocmask");
+
+	signal_set(&ev_sigusr1, SIGUSR1, on_sigusr1, NULL);
+	ret = signal_add(&ev_sigusr1, NULL);
+	if (ret < 0)
+		fatal_perror("signal_add");
+
+	signal_set(&ev_sigusr2, SIGUSR2, on_sigusr2, NULL);
+	ret = signal_add(&ev_sigusr2, NULL);
+	if (ret < 0)
+		fatal_perror("signal_add");
+
+	signal_set(&ev_sighup, SIGHUP, on_sighup, NULL);
+	ret = signal_add(&ev_sighup, NULL);
+	if (ret < 0)
+		fatal_perror("signal_add");
+
+	signal_set(&ev_sigterm, SIGTERM, on_sigterm, NULL);
+	ret = signal_add(&ev_sigterm, NULL);
+	if (ret < 0)
+		fatal_perror("signal_add");
+
+	signal_set(&ev_sigint, SIGINT, on_sigint, NULL);
+	ret = signal_add(&ev_sigint, NULL);
+	if (ret < 0)
+		fatal_perror("signal_add");
+}
+
+static void accept_start(void)
+{
+	struct List *el;
+	struct ListenSocket *ls;
+	event_cb_t cb;
+
+	cb = cf_is_pmgr_worker ? worker_on_accept : pmgr_on_accept;
+
+	statlist_for_each(el, &socket_list) {
+		ls = container_of(el, struct ListenSocket, node);
+
+		if (ls->active)
+			continue;
+
+		event_set(&ls->ev, ls->fd, EV_READ | EV_PERSIST, cb, NULL);
+		if (event_add(&ls->ev, NULL) < 0) {
+			log_warning("event_add() failed: %s", strerror(errno));
+			continue;
+		}
+		ls->active = true;
+	}
+}
+
+static bool connect_worker(struct Worker *worker)
+{
+	int sock;
+	int ret;
+	int sa_len;
+	struct sockaddr_un sa_un;
+
+	memset(&sa_un, 0, sizeof(sa_un));
+
+	sa_len = sizeof(sa_un);
+	sa_un.sun_family = AF_UNIX;
+	snprintf(sa_un.sun_path, sizeof(sa_un.sun_path),
+		 "%s/.s.PGSQL.%d", cf_unix_socket_dir, worker->port);
+
+	sock = socket(PF_UNIX, SOCK_STREAM, 0);
+        if (sock < 0)
+                goto fail;
+
+        if (!tune_socket(sock, true))
+                goto fail;
+
+        ret = safe_connect(sock, (struct sockaddr *)&sa_un, sa_len);
+        if (ret < 0)
+		goto fail;
+
+	worker->sock = sock;
+	log_info("pmgr connected to worker, pid=%d, sock=%d",
+		 worker->pid, worker->sock);
+	return true;
+
+fail:
+        log_warning("connect_worker() failed: %s", strerror(errno));
+        if (sock >= 0)
+                safe_close(sock);
+
+	return false;
+}
+
+static bool pmgr_setup(void)
+{
+	int i;
+	pid_t pid;
+	struct Worker *worker;
+	struct List *el;
+
+	/*
+	 * Keep original value since the create_sockets() that's going to be
+	 * called for each worker uses these global variables.
+	 */
+	cf_pmgr_listen_addr = cf_listen_addr;
+	cf_pmgr_listen_port = cf_listen_port;
+
+	/*
+	 * We don't want the workers to listen on any TCP connections,
+	 * just unix sockets.
+	 */
+	cf_listen_addr = NULL;
+
+	/*
+	 * Make sure the listen sockets are removed on exit. Call this before
+	 * forking since it's safe for workers to inherit the registration.
+	 */
+	atexit(pmgr_cleanup);
+
+	for (i = 0; i < cf_pmgr_workers; i++) {
+		cf_listen_port++;
+
+		create_sockets(&socket_list);
+
+		pid = fork();
+		if (pid < 0) {  /* This is error. */
+			fatal_perror("pmgr_setup");
+		} else if (pid == 0) {  /* This is worker. */
+			cf_is_pmgr_worker = true;
+			return false;
+		}
+
+		/* This is manager. */
+		worker = malloc(sizeof(*worker));
+		if (!worker)
+			fatal_perror("pmgr_setup");
+		worker->pid = pid;
+		worker->port = cf_listen_port;
+		worker->sock = -1;
+		statlist_append(&worker_list, &worker->node);
+
+		/*
+		 * We want to close the worker sockets in manager to avoid
+		 * leaking them since they're not going to be used.
+		 */
+		close_sockets(&socket_list);
+	}
+
+	/*
+	 * Make sure the variables are back at their original value
+	 * when calling create_sockets() on the manager.
+	 */
+	cf_listen_addr = cf_pmgr_listen_addr;
+	cf_listen_port = cf_pmgr_listen_port;
+
+	/*
+	 * Establish connection to the workers. We want to do it here
+	 * to give the workers some time to initialize after forking
+	 * before trying to connect.
+	 */
+	statlist_for_each(el, &worker_list) {
+		worker = container_of(el, struct Worker, node);
+		if (!connect_worker(worker))
+			fatal("failed to connect to worker");
+	}
+
+	if (!event_init())
+		fatal("event_init() failed");
+
+	create_sockets(&socket_list);
+	signals_setup();
+	accept_start();
+	return true;
+}
+
+static void pmgr_cleanup(void)
+{
+	if (!cf_is_pmgr_worker)
+		kill(0, SIGINT);
+	cleanup_sockets(&socket_list);
+}
+
+
+/*****************************************************************************
+ * Public
+ *****************************************************************************/
+
+void pmgr_worker_setup(void)
+{
+	accept_start();
+}
+
+void pmgr_run(void)
+{
+	if (cf_reboot)
+		fatal("cf_reboot currently not supported");
+	if (cf_daemon)
+		fatal("cf_daemon currently not supported");
+	if (cf_logfile && *cf_logfile)
+		fatal("cf_logfile currently not supported");
+	if (!cf_unix_socket_dir || !*cf_unix_socket_dir)
+		fatal("cf_unix_socket_dir must be set");
+
+	if (!pmgr_setup())
+		return; /* This is worker. */
+
+	while (cf_shutdown < 2)
+		event_loop(EVLOOP_ONCE);
+
+	/* Cleanup is registered with atexit(). */
+
+	exit(0);
+}
+
+#else /* !HAVE_PMGR */
+
+void pmgr_worker_setup(void)
+{
+	fatal("PMGR not supported");
+}
+
+void pmgr_run(void)
+{
+	fatal("PMGR not supported");
+}
+
+#endif

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -24,23 +24,9 @@
 
 #include <usual/netdb.h>
 
-struct ListenSocket {
-	struct List node;
-	int fd;
-	bool active;
-	struct event ev;
-	PgAddr addr;
-};
+
 
 static STATLIST(sock_list);
-
-/* hints for getaddrinfo(listen_addr) */
-static const struct addrinfo hints = {
-	.ai_family = AF_UNSPEC,
-	.ai_socktype = SOCK_STREAM,
-	.ai_protocol = IPPROTO_TCP,
-	.ai_flags = AI_PASSIVE,
-};
 
 /* should listening sockets be active or suspended? */
 static bool need_active = false;
@@ -51,188 +37,6 @@ static bool pooler_active = false;
 static struct event ev_err;
 static struct timeval err_timeout = {5, 0};
 
-static void tune_accept(int sock, bool on);
-
-/* atexit() cleanup func */
-static void cleanup_sockets(void)
-{
-	struct ListenSocket *ls;
-	struct List *el;
-
-	/* avoid cleanup if exit() while suspended */
-	if (cf_pause_mode == P_SUSPEND)
-		return;
-
-	while ((el = statlist_pop(&sock_list)) != NULL) {
-		ls = container_of(el, struct ListenSocket, node);
-		if (ls->fd > 0) {
-			safe_close(ls->fd);
-			ls->fd = 0;
-		}
-		if (pga_is_unix(&ls->addr)) {
-			char buf[sizeof(struct sockaddr_un) + 20];
-			snprintf(buf, sizeof(buf), "%s/.s.PGSQL.%d", cf_unix_socket_dir, cf_listen_port);
-			unlink(buf);
-		}
-		statlist_remove(&sock_list, &ls->node);
-		free(ls);
-	}
-}
-
-/*
- * initialize another listening socket.
- */
-static bool add_listen(int af, const struct sockaddr *sa, int salen)
-{
-	struct ListenSocket *ls;
-	int sock, res;
-	char buf[128];
-	const char *errpos;
-
-	log_debug("add_listen: %s", sa2str(sa, buf, sizeof(buf)));
-
-	/* create socket */
-	errpos = "socket";
-	sock = socket(af, SOCK_STREAM, 0);
-	if (sock < 0)
-		goto failed;
-
-	/* SO_REUSEADDR behaviour it default in WIN32.  */
-#ifndef WIN32
-	/* relaxed binding */
-	if (af != AF_UNIX) {
-		int val = 1;
-		errpos = "setsockopt";
-		res = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
-		if (res < 0)
-			goto failed;
-	}
-#endif
-
-#ifdef IPV6_V6ONLY
-	/* avoid ipv6 socket's attempt to takeover ipv4 port */
-	if (af == AF_INET6) {
-		int val = 1;
-		errpos = "setsockopt/IPV6_V6ONLY";
-		res = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
-		if (res < 0)
-			goto failed;
-	}
-#endif
-
-	/* bind it */
-	errpos = "bind";
-	res = bind(sock, sa, salen);
-	if (res < 0)
-		goto failed;
-
-	/* set common options */
-	errpos = "tune_socket";
-	if (!tune_socket(sock, (af == AF_UNIX)))
-		goto failed;
-
-	/* finally, accept connections */
-	errpos = "listen";
-	res = listen(sock, cf_listen_backlog);
-	if (res < 0)
-		goto failed;
-
-	errpos = "calloc";
-	ls = calloc(1, sizeof(*ls));
-	if (!ls)
-		goto failed;
-
-	list_init(&ls->node);
-	ls->fd = sock;
-	if (sa->sa_family == AF_UNIX) {
-		pga_set(&ls->addr, AF_UNIX, cf_listen_port);
-	} else {
-		pga_copy(&ls->addr, sa);
-	}
-
-	if (af == AF_UNIX) {
-		struct sockaddr_un *un = (struct sockaddr_un *)sa;
-		change_file_mode(un->sun_path, cf_unix_socket_mode, NULL, cf_unix_socket_group);
-	} else {
-		tune_accept(sock, cf_tcp_defer_accept);
-	}
-
-	log_info("listening on %s", sa2str(sa, buf, sizeof(buf)));
-	statlist_append(&sock_list, &ls->node);
-	return true;
-
-failed:
-	log_warning("Cannot listen on %s: %s(): %s",
-		    sa2str(sa, buf, sizeof(buf)),
-		    errpos, strerror(errno));
-	if (sock >= 0)
-		safe_close(sock);
-	return false;
-}
-
-static void create_unix_socket(const char *socket_dir, int listen_port)
-{
-	struct sockaddr_un un;
-	int res;
-	char lockfile[sizeof(struct sockaddr_un) + 10];
-	struct stat st;
-
-	/* fill sockaddr struct */
-	memset(&un, 0, sizeof(un));
-	un.sun_family = AF_UNIX;
-	snprintf(un.sun_path, sizeof(un.sun_path),
-		"%s/.s.PGSQL.%d", socket_dir, listen_port);
-
-	/* check for lockfile */
-	snprintf(lockfile, sizeof(lockfile), "%s.lock", un.sun_path);
-	res = lstat(lockfile, &st);
-	if (res == 0)
-		fatal("unix port %d is in use", listen_port);
-
-	/* expect old bouncer gone */
-	unlink(un.sun_path);
-
-	add_listen(AF_UNIX, (const struct sockaddr *)&un, sizeof(un));
-}
-
-/*
- * Notify pooler only when also data is arrived.
- *
- * optval specifies how long after connection attempt to wait for data.
- *
- * Related to tcp_synack_retries sysctl, default 5 (corresponds 180 secs).
- *
- * SO_ACCEPTFILTER needs to be set after listen(), maybe TCP_DEFER_ACCEPT too.
- */
-static void tune_accept(int sock, bool on)
-{
-	const char *act = on ? "install" : "uninstall";
-	int res = 0;
-#ifdef TCP_DEFER_ACCEPT
-	int val = 45; /* FIXME: proper value */
-	socklen_t vlen = sizeof(val);
-	res = getsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, &val, &vlen);
-	log_noise("old TCP_DEFER_ACCEPT on %d = %d", sock, val);
-	val = on ? 1 : 0;
-	log_noise("%s TCP_DEFER_ACCEPT on %d", act, sock);
-	res = setsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, &val, sizeof(val));
-#else
-#if 0
-#ifdef SO_ACCEPTFILTER
-	struct accept_filter_arg af, *afp = on ? &af : NULL;
-	socklen_t af_len = on ? sizeof(af) : 0;
-	memset(&af, 0, sizeof(af));
-	strcpy(af.af_name, "dataready");
-	log_noise("%s SO_ACCEPTFILTER on %d", act, sock);
-	res = setsockopt(sock, SOL_SOCKET, SO_ACCEPTFILTER, afp, af_len);
-#endif
-#endif
-#endif
-	if (res < 0)
-		log_warning("tune_accept: %s TCP_DEFER_ACCEPT/SO_ACCEPTFILTER: %s",
-			    act, strerror(errno));
-}
-
 void pooler_tune_accept(bool on)
 {
 	struct List *el;
@@ -242,6 +46,11 @@ void pooler_tune_accept(bool on)
 		if (!pga_is_unix(&ls->addr))
 			tune_accept(ls->fd, on);
 	}
+}
+
+static void atexit_cb(void)
+{
+	cleanup_sockets(&sock_list);
 }
 
 static void err_wait_func(int sock, short flags, void *arg)
@@ -409,55 +218,18 @@ void per_loop_pooler_maint(void)
 		suspend_pooler();
 }
 
-static bool parse_addr(void *arg, const char *addr)
-{
-	int res;
-	char service[64];
-	struct addrinfo *ai, *gaires = NULL;
-	bool ok;
-
-	if (!*addr)
-		return true;
-	if (strcmp(addr, "*") == 0)
-		addr = NULL;
-	snprintf(service, sizeof(service), "%d", cf_listen_port);
-
-	res = getaddrinfo(addr, service, &hints, &gaires);
-	if (res != 0) {
-		fatal("getaddrinfo('%s', '%d') = %s [%d]", addr ? addr : "*",
-		      cf_listen_port, gai_strerror(res), res);
-	}
-
-	for (ai = gaires; ai; ai = ai->ai_next) {
-		ok = add_listen(ai->ai_family, ai->ai_addr, ai->ai_addrlen);
-		/* it's unclear whether all or only first result should be used */
-		if (0 && ok)
-			break;
-	}
-
-	freeaddrinfo(gaires);
-	return true;
-}
-
 /* listen on socket - should happen after all other initializations */
 void pooler_setup(void)
 {
-	bool ok;
 	static int init_done = 0;
 
 	if (!init_done) {
 		/* remove socket on shutdown */
-		atexit(cleanup_sockets);
+		atexit(atexit_cb);
 		init_done = 1;
 	}
 
-	ok = parse_word_list(cf_listen_addr, parse_addr, NULL);
-	if (!ok)
-		fatal("failed to parse listen_addr list: %s", cf_listen_addr);
-
-	if (cf_unix_socket_dir && *cf_unix_socket_dir)
-		create_unix_socket(cf_unix_socket_dir, cf_listen_port);
-
+	create_sockets(&sock_list);
 	if (!statlist_count(&sock_list))
 		fatal("nowhere to listen on");
 

--- a/src/util.c
+++ b/src/util.c
@@ -440,3 +440,241 @@ const char *pga_details(const PgAddr *a, char *dst, int dstlen)
 	}
 	return dst;
 }
+
+/* hints for getaddrinfo(listen_addr) */
+static const struct addrinfo hints = {
+	.ai_family = AF_UNSPEC,
+	.ai_socktype = SOCK_STREAM,
+	.ai_protocol = IPPROTO_TCP,
+	.ai_flags = AI_PASSIVE,
+};
+
+/*
+ * initialize another listening socket.
+ */
+static struct ListenSocket *init_socket(int af, const struct sockaddr *sa, int salen)
+{
+	struct ListenSocket *ls;
+	int sock, res;
+	char buf[128];
+	const char *errpos;
+
+	log_debug("init_socket: %s", sa2str(sa, buf, sizeof(buf)));
+
+	/* create socket */
+	errpos = "socket";
+	sock = socket(af, SOCK_STREAM, 0);
+	if (sock < 0)
+		goto failed;
+
+	/* SO_REUSEADDR behaviour it default in WIN32.  */
+#ifndef WIN32
+	/* relaxed binding */
+	if (af != AF_UNIX) {
+		int val = 1;
+		errpos = "setsockopt";
+		res = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+		if (res < 0)
+			goto failed;
+	}
+#endif
+
+#ifdef IPV6_V6ONLY
+	/* avoid ipv6 socket's attempt to takeover ipv4 port */
+	if (af == AF_INET6) {
+		int val = 1;
+		errpos = "setsockopt/IPV6_V6ONLY";
+		res = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
+		if (res < 0)
+			goto failed;
+	}
+#endif
+
+	/* bind it */
+	errpos = "bind";
+	res = bind(sock, sa, salen);
+	if (res < 0)
+		goto failed;
+
+	/* set common options */
+	errpos = "tune_socket";
+	if (!tune_socket(sock, (af == AF_UNIX)))
+		goto failed;
+
+	/* finally, accept connections */
+	errpos = "listen";
+	res = listen(sock, cf_listen_backlog);
+	if (res < 0)
+		goto failed;
+
+	if (af == AF_UNIX) {
+		struct sockaddr_un *un = (struct sockaddr_un *)sa;
+		change_file_mode(un->sun_path, cf_unix_socket_mode, NULL, cf_unix_socket_group);
+	} else {
+		tune_accept(sock, cf_tcp_defer_accept);
+	}
+
+	errpos = "calloc";
+	ls = calloc(1, sizeof(*ls));
+	if (!ls)
+		goto failed;
+
+	list_init(&ls->node);
+	ls->fd = sock;
+	if (sa->sa_family == AF_UNIX) {
+		pga_set(&ls->addr, AF_UNIX, cf_listen_port);
+	} else {
+		pga_copy(&ls->addr, sa);
+	}
+
+	if (af == AF_UNIX) {
+		struct sockaddr_un *un = (struct sockaddr_un *)sa;
+		change_file_mode(un->sun_path, cf_unix_socket_mode, NULL, cf_unix_socket_group);
+	} else {
+		tune_accept(sock, cf_tcp_defer_accept);
+	}
+
+	log_info("listening on %s", sa2str(sa, buf, sizeof(buf)));
+	return ls;
+
+failed:
+	log_warning("Cannot listen on %s: %s(): %s",
+		    sa2str(sa, buf, sizeof(buf)),
+		    errpos, strerror(errno));
+	if (sock >= 0)
+		safe_close(sock);
+	return NULL;
+}
+
+static bool parse_addr(void *arg, const char *addr)
+{
+	int res;
+	char service[64];
+	struct addrinfo *ai, *gaires = NULL;
+	struct ListenSocket *ls;
+	struct StatList *sock_list = arg;
+
+	if (!*addr)
+		return true;
+	if (strcmp(addr, "*") == 0)
+		addr = NULL;
+	snprintf(service, sizeof(service), "%d", cf_listen_port);
+
+	res = getaddrinfo(addr, service, &hints, &gaires);
+	if (res != 0) {
+		fatal("getaddrinfo('%s', '%d') = %s [%d]", addr ? addr : "*",
+		      cf_listen_port, gai_strerror(res), res);
+	}
+
+	for (ai = gaires; ai; ai = ai->ai_next) {
+		ls = init_socket(ai->ai_family, ai->ai_addr, ai->ai_addrlen);
+		if (ls)
+			statlist_append(sock_list, &ls->node);
+		/* it's unclear whether all or only first result should be used */
+	}
+
+	freeaddrinfo(gaires);
+	return true;
+}
+
+static struct ListenSocket *create_unix_socket(void)
+{
+	struct sockaddr_un un;
+	int res;
+	char lockfile[sizeof(struct sockaddr_un) + 10];
+	struct stat st;
+
+	/* fill sockaddr struct */
+	memset(&un, 0, sizeof(un));
+	un.sun_family = AF_UNIX;
+	snprintf(un.sun_path, sizeof(un.sun_path),
+		"%s/.s.PGSQL.%d", cf_unix_socket_dir, cf_listen_port);
+
+	/* check for lockfile */
+	snprintf(lockfile, sizeof(lockfile), "%s.lock", un.sun_path);
+	res = lstat(lockfile, &st);
+	if (res == 0)
+		fatal("unix port %d is in use", cf_listen_port);
+
+	/* expect old bouncer gone */
+	unlink(un.sun_path);
+
+	return init_socket(AF_UNIX, (const struct sockaddr *)&un, sizeof(un));
+}
+
+void create_sockets(struct StatList *sock_list)
+{
+	bool ok;
+	struct ListenSocket *ls;
+
+	if (cf_listen_addr && *cf_listen_addr) {
+		ok = parse_word_list(cf_listen_addr, parse_addr, sock_list);
+		if (!ok)
+			fatal("failed to parse listen_addr list: %s", cf_listen_addr);
+	}
+
+	if (cf_unix_socket_dir && *cf_unix_socket_dir) {
+		ls = create_unix_socket();
+		if (ls)
+			statlist_append(sock_list, &ls->node);
+	}
+}
+
+void cleanup_sockets(struct StatList *sock_list)
+{
+	struct ListenSocket *ls;
+	struct List *el;
+
+	while ((el = statlist_pop(sock_list)) != NULL) {
+		ls = container_of(el, struct ListenSocket, node);
+		if (ls->fd > 0) {
+			safe_close(ls->fd);
+			ls->fd = 0;
+		}
+		if (pga_is_unix(&ls->addr)) {
+			char buf[sizeof(struct sockaddr_un) + 20];
+			snprintf(buf, sizeof(buf), "%s/.s.PGSQL.%d", cf_unix_socket_dir, cf_listen_port);
+			unlink(buf);
+		}
+		statlist_remove(sock_list, &ls->node);
+		free(ls);
+	}
+}
+
+/*
+ * Notify pooler only when also data is arrived.
+ *
+ * optval specifies how long after connection attempt to wait for data.
+ *
+ * Related to tcp_synack_retries sysctl, default 5 (corresponds 180 secs).
+ *
+ * SO_ACCEPTFILTER needs to be set after listen(), maybe TCP_DEFER_ACCEPT too.
+ */
+void tune_accept(int sock, bool on)
+{
+	const char *act = on ? "install" : "uninstall";
+	int res = 0;
+#ifdef TCP_DEFER_ACCEPT
+	int val = 45; /* FIXME: proper value */
+	socklen_t vlen = sizeof(val);
+	res = getsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, &val, &vlen);
+	log_noise("old TCP_DEFER_ACCEPT on %d = %d", sock, val);
+	val = on ? 1 : 0;
+	log_noise("%s TCP_DEFER_ACCEPT on %d", act, sock);
+	res = setsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, &val, sizeof(val));
+#else
+#if 0
+#ifdef SO_ACCEPTFILTER
+	struct accept_filter_arg af, *afp = on ? &af : NULL;
+	socklen_t af_len = on ? sizeof(af) : 0;
+	memset(&af, 0, sizeof(af));
+	strcpy(af.af_name, "dataready");
+	log_noise("%s SO_ACCEPTFILTER on %d", act, sock);
+	res = setsockopt(sock, SOL_SOCKET, SO_ACCEPTFILTER, afp, af_len);
+#endif
+#endif
+#endif
+	if (res < 0)
+		log_warning("tune_accept: %s TCP_DEFER_ACCEPT/SO_ACCEPTFILTER: %s",
+			    act, strerror(errno));
+}


### PR DESCRIPTION
When pgbouncer is compiled with process manager support (pmgr) and
cf_pmgr_workers is larger than 1, pgbouncer will fork into manager
process and a number of worker processes. Pgbouncer the listens for
new connections and once connected it selects one of the workers
(currently round-robin) and sends the client socket to the worker
via unix domain socket the worker is listening on. The worker then
proceeds to work with the client socket as usual.

The manager process also handles signals by sending the incoming signal
to all workers.

cf_reboot, cf_daemon and cf_logfile are not currently supported when
using pmgr and cf_unix_socket_dir is required.